### PR TITLE
A couple of changes

### DIFF
--- a/src/GodMode.sol
+++ b/src/GodMode.sol
@@ -13,8 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity >=0.6.12;
-pragma experimental ABIEncoderV2;
+pragma solidity >=0.8.0;
 
 import {
     WardsAbstract,
@@ -70,7 +69,7 @@ library GodMode {
     
     address constant public VM_ADDR = address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
 
-    function vm() internal view returns (Vm) {
+    function vm() internal pure returns (Vm) {
         return Vm(VM_ADDR);
     }
 

--- a/src/MCD.sol
+++ b/src/MCD.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity >=0.6.12;
+pragma solidity >=0.8.0;
 
 import "dss-interfaces/Interfaces.sol";
 
@@ -80,7 +80,7 @@ contract MCD {
 
 contract MCDMainnet is MCD {
 
-    constructor() public {
+    constructor() {
         loadFromChainlog(ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F));
     }
 
@@ -88,7 +88,7 @@ contract MCDMainnet is MCD {
 
 contract MCDGoerli is MCD {
 
-    constructor() public {
+    constructor() {
         loadFromChainlog(ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F));
     }
 

--- a/src/MCDUser.sol
+++ b/src/MCDUser.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity >=0.6.12;
+pragma solidity >=0.8.0;
 
 import "dss-interfaces/Interfaces.sol";
 
@@ -29,7 +29,7 @@ contract MCDUser {
 
     constructor(
         MCD _mcd
-    ) public {
+    ) {
         mcd = _mcd;
     }
 

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity >=0.6.12;
+pragma solidity >=0.8.0;
 
 import "../DSSTest.sol";
 

--- a/src/tests/IntegrationTest_0_8_0.t.sol
+++ b/src/tests/IntegrationTest_0_8_0.t.sol
@@ -13,9 +13,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity 0.6.12;
+pragma solidity 0.8.0;
 
 import "./IntegrationTest.t.sol";
 
-contract IntegrationTest_0_6_12 is IntegrationTest {
+contract IntegrationTest_0_8_0 is IntegrationTest {
 }

--- a/src/tests/IntegrationTest_0_8_13.t.sol
+++ b/src/tests/IntegrationTest_0_8_13.t.sol
@@ -13,9 +13,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity 0.8.9;
+pragma solidity 0.8.13;
 
 import "./IntegrationTest.t.sol";
 
-contract IntegrationTest_0_8_9 is IntegrationTest {
+contract IntegrationTest_0_8_13 is IntegrationTest {
 }


### PR DESCRIPTION
* add assert revert (https://github.com/dapphub/ds-test/pull/26/files)
* remove 0.6.12 support 
* update to 0.8.0 as minimum supported version along with warning fixes
* make DSSTest virtual functions optional and default to empty environment instead of erroring with auto-detect