### PR TITLE
Refactor MCD into a DssInstance struct

### DIFF
--- a/src/DSSTest.sol
+++ b/src/DSSTest.sol
@@ -17,7 +17,13 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 
-import {GodMode} from "./GodMode.sol";
+import {
+    GodMode,
+    MCD,
+    MCDUser,
+    DssInstance,
+    DssIlkInstance
+} from "./MCD.sol";
 
 interface AuthLike {
     function wards(address) external view returns (uint256);

--- a/src/DSSTest.sol
+++ b/src/DSSTest.sol
@@ -18,8 +18,6 @@ pragma solidity >=0.8.0;
 import "forge-std/Test.sol";
 
 import {GodMode} from "./GodMode.sol";
-import {MCD,Ilk} from "./MCD.sol";
-import {MCDUser} from "./MCDUser.sol";
 
 interface AuthLike {
     function wards(address) external view returns (uint256);

--- a/src/MCD.sol
+++ b/src/MCD.sol
@@ -57,6 +57,7 @@ struct DssInstance {
     CureAbstract cure;
     FlapAbstract flap;
     FlopAbstract flop;
+    ESMAbstract esm;
 }
 
 struct DssIlkInstance {
@@ -98,6 +99,7 @@ library MCD {
         dss.cure = CureAbstract(getAddressOrNull(dss, "MCD_CURE"));
         dss.flap = FlapAbstract(getAddressOrNull(dss, "MCD_FLAP"));
         dss.flop = FlopAbstract(getAddressOrNull(dss, "MCD_FLOP"));
+        dss.esm = ESMAbstract(getAddressOrNull(dss, "MCD_ESM"));
     }
 
     function bytesToBytes32(bytes memory b) private pure returns (bytes32) {
@@ -181,6 +183,7 @@ library MCD {
         if (address(dss.spotter) != address(0)) GodMode.setWard(address(dss.spotter), who, 1);
         if (address(dss.end) != address(0)) GodMode.setWard(address(dss.end), who, 1);
         if (address(dss.cure) != address(0)) GodMode.setWard(address(dss.cure), who, 1);
+        if (address(dss.esm) != address(0)) GodMode.setWard(address(dss.esm), who, 1);
     }
 
     /// @dev Give who a ward on all core contracts to this address

--- a/src/MCD.sol
+++ b/src/MCD.sol
@@ -43,107 +43,61 @@ contract DSValue {
     }
 }
 
-struct Ilk {
+struct DssInstance {
+    ChainlogAbstract chainlog;
+    VatAbstract vat;
+    DaiJoinAbstract daiJoin;
+    DaiAbstract dai;
+    VowAbstract vow;
+    DogAbstract dog;
+    PotAbstract pot;
+    JugAbstract jug;
+    SpotAbstract spotter;
+    EndAbstract end;
+    CureAbstract cure;
+    FlapAbstract flap;
+    FlopAbstract flop;
+}
+
+struct DssIlkInstance {
     DSTokenAbstract gem;
     OsmAbstract pip;
     GemJoinAbstract join;
     ClipAbstract clip;
 }
 
-/// @dev An instance of MCD with all relevant references
-contract MCD {
+library MCD {
 
     uint256 constant WAD = 10 ** 18;
     uint256 constant RAY = 10 ** 27;
     uint256 constant RAD = 10 ** 45;
 
-    ChainlogAbstract public chainlog;
-
-    // Core MCD
-    VatAbstract public vat;
-    DaiJoinAbstract public daiJoin;
-    DaiAbstract public dai;
-    VowAbstract public vow;
-    DogAbstract public dog;
-    PotAbstract public pot;
-    JugAbstract public jug;
-    SpotAbstract public spotter;
-    EndAbstract public end;
-    CureAbstract public cure;
-    FlapAbstract public flap;
-    FlopAbstract public flop;
-
-    // ETH-A
-    DSTokenAbstract public weth;
-    OsmAbstract public wethPip;
-    GemJoinAbstract public wethAJoin;
-    ClipAbstract public wethAClip;
-
-    // WBTC-A
-    DSTokenAbstract public wbtc;
-    OsmAbstract public wbtcPip;
-    GemJoinAbstract public wbtcAJoin;
-    ClipAbstract public wbtcAClip;
-
-    function getAddressOrNull(bytes32 key) public view returns (address) {
-        try chainlog.getAddress(key) returns (address a) {
+    function getAddressOrNull(DssInstance memory dss, bytes32 key) internal view returns (address) {
+        try dss.chainlog.getAddress(key) returns (address a) {
             return a;
         } catch {
             return address(0);
         }
     }
 
-    function loadCore(
-        address _vat,
-        address _daiJoin,
-        address _dai,
-        address _vow,
-        address _dog,
-        address _pot,
-        address _jug,
-        address _spotter,
-        address _end,
-        address _cure
-    ) public {
-        vat = VatAbstract(_vat);
-        daiJoin = DaiJoinAbstract(_daiJoin);
-        dai = DaiAbstract(_dai);
-        vow = VowAbstract(_vow);
-        dog = DogAbstract(_dog);
-        pot = PotAbstract(_pot);
-        jug = JugAbstract(_jug);
-        spotter = SpotAbstract(_spotter);
-        end = EndAbstract(_end);
-        cure = CureAbstract(_cure);
-
-        giveAdminAccess(address(this));
+    function loadFromChainlog(address chainlog) internal view returns (DssInstance memory dss) {
+        return loadFromChainlog(ChainlogAbstract(chainlog));
     }
 
-    function loadFromChainlog(ChainlogAbstract _chainlog) public {
-        chainlog = _chainlog;
-
-        vat = VatAbstract(getAddressOrNull("MCD_VAT"));
-        daiJoin = DaiJoinAbstract(getAddressOrNull("MCD_JOIN_DAI"));
-        dai = DaiAbstract(getAddressOrNull("MCD_DAI"));
-        vow = VowAbstract(getAddressOrNull("MCD_VOW"));
-        dog = DogAbstract(getAddressOrNull("MCD_DOG"));
-        pot = PotAbstract(getAddressOrNull("MCD_POT"));
-        jug = JugAbstract(getAddressOrNull("MCD_JUG"));
-        spotter = SpotAbstract(getAddressOrNull("MCD_SPOT"));
-        end = EndAbstract(getAddressOrNull("MCD_END"));
-        cure = CureAbstract(getAddressOrNull("MCD_CURE"));
-        flap = FlapAbstract(getAddressOrNull("MCD_FLAP"));
-        flop = FlopAbstract(getAddressOrNull("MCD_FLOP"));
-
-        weth = DSTokenAbstract(getAddressOrNull("ETH"));
-        wethPip = OsmAbstract(getAddressOrNull("PIP_ETH"));
-        wethAJoin = GemJoinAbstract(getAddressOrNull("MCD_JOIN_ETH_A"));
-        wethAClip = ClipAbstract(getAddressOrNull("MCD_CLIP_ETH_A"));
-
-        wbtc = DSTokenAbstract(getAddressOrNull("WBTC"));
-        wbtcPip = OsmAbstract(getAddressOrNull("PIP_WBTC"));
-        wbtcAJoin = GemJoinAbstract(getAddressOrNull("MCD_JOIN_WBTC_A"));
-        wbtcAClip = ClipAbstract(getAddressOrNull("MCD_CLIP_WBTC_A"));
+    function loadFromChainlog(ChainlogAbstract chainlog) internal view returns (DssInstance memory dss) {
+        dss.chainlog = chainlog;
+        dss.vat = VatAbstract(getAddressOrNull(dss, "MCD_VAT"));
+        dss.daiJoin = DaiJoinAbstract(getAddressOrNull(dss, "MCD_JOIN_DAI"));
+        dss.dai = DaiAbstract(getAddressOrNull(dss, "MCD_DAI"));
+        dss.vow = VowAbstract(getAddressOrNull(dss, "MCD_VOW"));
+        dss.dog = DogAbstract(getAddressOrNull(dss, "MCD_DOG"));
+        dss.pot = PotAbstract(getAddressOrNull(dss, "MCD_POT"));
+        dss.jug = JugAbstract(getAddressOrNull(dss, "MCD_JUG"));
+        dss.spotter = SpotAbstract(getAddressOrNull(dss, "MCD_SPOT"));
+        dss.end = EndAbstract(getAddressOrNull(dss, "MCD_END"));
+        dss.cure = CureAbstract(getAddressOrNull(dss, "MCD_CURE"));
+        dss.flap = FlapAbstract(getAddressOrNull(dss, "MCD_FLAP"));
+        dss.flop = FlopAbstract(getAddressOrNull(dss, "MCD_FLOP"));
     }
 
     function bytesToBytes32(bytes memory b) private pure returns (bytes32) {
@@ -154,111 +108,88 @@ contract MCD {
         return out;
     }
 
-    function getIlk(string memory gem, string memory variant) public view returns (Ilk memory) {
-        return Ilk(
-            DSTokenAbstract(getAddressOrNull(bytesToBytes32(bytes(gem)))),
-            OsmAbstract(getAddressOrNull(bytesToBytes32(abi.encodePacked("PIP_", gem)))),
-            GemJoinAbstract(getAddressOrNull(bytesToBytes32(abi.encodePacked("MCD_JOIN_", gem, "_", variant)))),
-            ClipAbstract(getAddressOrNull(bytesToBytes32(abi.encodePacked("MCD_CLIP_", gem, "_", variant))))
+    function getIlk(DssInstance memory dss, string memory gem, string memory variant) internal view returns (DssIlkInstance memory) {
+        return DssIlkInstance(
+            DSTokenAbstract(getAddressOrNull(dss, bytesToBytes32(bytes(gem)))),
+            OsmAbstract(getAddressOrNull(dss, bytesToBytes32(abi.encodePacked("PIP_", gem)))),
+            GemJoinAbstract(getAddressOrNull(dss, bytesToBytes32(abi.encodePacked("MCD_JOIN_", gem, "_", variant)))),
+            ClipAbstract(getAddressOrNull(dss, bytesToBytes32(abi.encodePacked("MCD_CLIP_", gem, "_", variant))))
         );
-    }
-
-    /// @dev Initialize the core of MCD
-    function init() public {
-        vat.rely(address(jug));
-        vat.rely(address(dog));
-        vat.rely(address(pot));
-        vat.rely(address(jug));
-        vat.rely(address(spotter));
-        vat.rely(address(end));
-
-        dai.rely(address(daiJoin));
-
-        dog.file("vow", address(vow));
-
-        pot.rely(address(end));
-
-        spotter.rely(address(end));
-
-        end.file("vat", address(vat));
-        end.file("pot", address(pot));
-        end.file("spot", address(spotter));
-        end.file("cure", address(cure));
-        end.file("vow", address(vow));
-
-        cure.rely(address(end));
     }
 
     /// @dev Initialize a dummy ilk with a $1 DSValue pip without liquidations
     function initIlk(
+        DssInstance memory dss,
         bytes32 ilk
-    ) public {
+    ) internal {
         DSValue pip = new DSValue();
         pip.poke(bytes32(WAD));
-        initIlk(ilk, address(0), address(pip));
+        initIlk(dss, ilk, address(0), address(pip));
     }
 
     /// @dev Initialize an ilk with a $1 DSValue pip without liquidations
     function initIlk(
+        DssInstance memory dss,
         bytes32 ilk,
         address join
-    ) public {
+    ) internal {
         DSValue pip = new DSValue();
         pip.poke(bytes32(WAD));
-        initIlk(ilk, join, address(pip));
+        initIlk(dss, ilk, join, address(pip));
     }
 
     /// @dev Initialize an ilk without liquidations
     function initIlk(
+        DssInstance memory dss,
         bytes32 ilk,
         address join,
         address pip
-    ) public {
-        vat.init(ilk);
-        jug.init(ilk);
+    ) internal {
+        dss.vat.init(ilk);
+        dss.jug.init(ilk);
 
-        vat.rely(join);
+        dss.vat.rely(join);
 
-        spotter.file(ilk, "pip", pip);
-        spotter.file(ilk, "mat", RAY);
-        spotter.poke(ilk);
+        dss.spotter.file(ilk, "pip", pip);
+        dss.spotter.file(ilk, "mat", RAY);
+        dss.spotter.poke(ilk);
     }
 
     /// @dev Initialize an ilk with liquidations
     function initIlk(
+        DssInstance memory dss,
         bytes32 ilk,
         address join,
         address pip,
         address clip,
         address clipCalc
-    ) public {
-        initIlk(ilk, join, pip);
+    ) internal {
+        initIlk(dss, ilk, join, pip);
 
         // TODO liquidations
         clip; clipCalc;
     }
 
     /// @dev Give who a ward on all core contracts
-    function giveAdminAccess(address who) public {
-        if (address(vat) != address(0)) GodMode.setWard(address(vat), who, 1);
-        if (address(dai) != address(0)) GodMode.setWard(address(dai), who, 1);
-        if (address(vow) != address(0)) GodMode.setWard(address(vow), who, 1);
-        if (address(dog) != address(0)) GodMode.setWard(address(dog), who, 1);
-        if (address(pot) != address(0)) GodMode.setWard(address(pot), who, 1);
-        if (address(jug) != address(0)) GodMode.setWard(address(jug), who, 1);
-        if (address(spotter) != address(0)) GodMode.setWard(address(spotter), who, 1);
-        if (address(end) != address(0)) GodMode.setWard(address(end), who, 1);
-        if (address(cure) != address(0)) GodMode.setWard(address(cure), who, 1);
+    function giveAdminAccess(DssInstance memory dss, address who) internal {
+        if (address(dss.vat) != address(0)) GodMode.setWard(address(dss.vat), who, 1);
+        if (address(dss.dai) != address(0)) GodMode.setWard(address(dss.dai), who, 1);
+        if (address(dss.vow) != address(0)) GodMode.setWard(address(dss.vow), who, 1);
+        if (address(dss.dog) != address(0)) GodMode.setWard(address(dss.dog), who, 1);
+        if (address(dss.pot) != address(0)) GodMode.setWard(address(dss.pot), who, 1);
+        if (address(dss.jug) != address(0)) GodMode.setWard(address(dss.jug), who, 1);
+        if (address(dss.spotter) != address(0)) GodMode.setWard(address(dss.spotter), who, 1);
+        if (address(dss.end) != address(0)) GodMode.setWard(address(dss.end), who, 1);
+        if (address(dss.cure) != address(0)) GodMode.setWard(address(dss.cure), who, 1);
     }
 
-    /// @dev Give who a ward on all core contracts to both caller and this MCD instance
-    function giveAdminAccess() public {
-        giveAdminAccess(address(this));
-        giveAdminAccess(address(msg.sender));
+    /// @dev Give who a ward on all core contracts to this address
+    function giveAdminAccess(DssInstance memory dss) internal {
+        giveAdminAccess(dss, address(this));
     }
 
-    function newUser() public returns (MCDUser) {
-        return new MCDUser(this);
+    function newUser(DssInstance memory dss) internal returns (MCDUser) {
+        return new MCDUser(dss);
     }
 
 }

--- a/src/MCDUser.sol
+++ b/src/MCDUser.sol
@@ -18,19 +18,19 @@ pragma solidity >=0.8.0;
 import "dss-interfaces/Interfaces.sol";
 
 import {GodMode} from "./GodMode.sol";
-import {MCD} from "./MCD.sol";
+import {DssInstance} from "./MCD.sol";
 
 /// @dev A user which can perform actions in MCD
 contract MCDUser {
 
     using GodMode for *;
 
-    MCD mcd;
+    DssInstance dss;
 
     constructor(
-        MCD _mcd
+        DssInstance memory _dss
     ) {
-        mcd = _mcd;
+        dss = _dss;
     }
 
     /// @dev Create an auction on the provided ilk
@@ -50,18 +50,18 @@ contract MCDUser {
         join.join(address(this), amount);
         token.setBalance(address(this), prevBalance);
         token.approve(address(join), prevAllowance);
-        (,uint256 rate, uint256 spot,,) = mcd.vat().ilks(ilk);
+        (,uint256 rate, uint256 spot,,) = dss.vat.ilks(ilk);
         uint256 art = spot * amount / rate;
         uint256 ink = amount * (10 ** (18 - token.decimals()));
-        mcd.vat().frob(ilk, address(this), address(this), address(this), int256(ink), int256(art));
+        dss.vat.frob(ilk, address(this), address(this), address(this), int256(ink), int256(art));
 
         // Temporarily increase the liquidation threshold to liquidate this one vault then reset it
-        uint256 prevWard = mcd.vat().wards(address(this));
-        mcd.vat().setWard(address(this), 1);
-        mcd.vat().file(ilk, "spot", spot / 2);
-        mcd.dog().bark(ilk, address(this), address(this));
-        mcd.vat().file(ilk, "spot", spot);
-        mcd.vat().setWard(address(this), prevWard);
+        uint256 prevWard = dss.vat.wards(address(this));
+        dss.vat.setWard(address(this), 1);
+        dss.vat.file(ilk, "spot", spot / 2);
+        dss.dog.bark(ilk, address(this), address(this));
+        dss.vat.file(ilk, "spot", spot);
+        dss.vat.setWard(address(this), prevWard);
     }
 
 }

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -61,6 +61,18 @@ contract Domain {
         return config.readBytes32(string.concat(".domains.", name, ".", key));
     }
 
+    function bytesToBytes32(bytes memory b) private pure returns (bytes32) {
+        bytes32 out;
+        for (uint256 i = 0; i < b.length; i++) {
+            out |= bytes32(b[i] & 0xFF) >> (i * 8);
+        }
+        return out;
+    }
+
+    function readConfigBytes32FromString(string memory key) public returns (bytes32) {
+        return bytesToBytes32(bytes(readConfigString(key)));
+    }
+
     function loadDssFromChainlog() public {
         _dss = MCD.loadFromChainlog(readConfigAddress("chainlog"));
     }

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -18,7 +18,7 @@ pragma solidity >=0.8.0;
 import {stdJson} from "forge-std/StdJson.sol";
 import {ChainlogAbstract} from "dss-interfaces/Interfaces.sol";
 
-import {MCD} from "../MCD.sol";
+import {MCD,DssInstance} from "../MCD.sol";
 import {GodMode,Vm} from "../GodMode.sol";
 
 contract Domain {
@@ -27,7 +27,7 @@ contract Domain {
 
     string public config;
     string public name;
-    MCD public mcd;
+    DssInstance private _dss;
     Vm public vm;
     uint256 public forkId;
 
@@ -61,9 +61,12 @@ contract Domain {
         return config.readBytes32(string.concat(".domains.", name, ".", key));
     }
 
-    function loadMCDFromChainlog() public {
-        mcd = new MCD();
-        mcd.loadFromChainlog(ChainlogAbstract(config.readAddress(string.concat(".domains.", name, ".chainlog"))));
+    function loadDssFromChainlog() public {
+        _dss = MCD.loadFromChainlog(readConfigAddress("chainlog"));
+    }
+
+    function dss() public view returns (DssInstance memory) {
+        return _dss;
     }
     
     function selectFork() public {

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -18,7 +18,6 @@ pragma solidity ^0.8.16;
 import "dss-interfaces/Interfaces.sol";
 
 import "../DSSTest.sol";
-import "../MCD.sol";
 import "../domains/RootDomain.sol";
 import "../domains/OptimismDomain.sol";
 import "../domains/ArbitrumDomain.sol";
@@ -42,7 +41,7 @@ contract IntegrationTest is DSSTest {
     string config;
     RootDomain rootDomain;
     DssInstance dss;
-    DssIlkInstance weth;
+    DssIlkInstance ethA;
 
     MCDUser user1;
     MCDUser user2;
@@ -58,7 +57,7 @@ contract IntegrationTest is DSSTest {
         rootDomain.selectFork();
         rootDomain.loadDssFromChainlog();
         dss = rootDomain.dss(); // For ease of access
-        weth = dss.getIlk("ETH", "A");
+        ethA = dss.getIlk("ETH", "A");
     }
 
     function postSetup() internal virtual override {
@@ -76,9 +75,9 @@ contract IntegrationTest is DSSTest {
     }
 
     function test_create_liquidation() public {
-        uint256 prevKicks = weth.clip.kicks();
-        user1.createAuction(weth.join, 100 ether);
-        assertEq(weth.clip.kicks(), prevKicks + 1);
+        uint256 prevKicks = ethA.clip.kicks();
+        user1.createAuction(ethA.join, 100 ether);
+        assertEq(ethA.clip.kicks(), prevKicks + 1);
     }
 
     function test_auth() public {


### PR DESCRIPTION
This will improve compatibility with the new library-style deploys as we no longer have a layer of indirection with the `MCD` contract instance. `DssInstance` can directly be passed around and a library is now used to operate on it.

An example of why this is better: https://github.com/makerdao/dss-bridge/pull/2/files#diff-07e8273439a64d3577ede2634bdd66a71952b4955d846f763e092328d37ddcd6R50

Instead of initializing a `DssInstance` inside `dss-test` it can be initialized from the actual repository such as `xdomain-dss`. This consolidates all the logic into these re-usable deploy scripts so integration tests always match the real deploys.