### PR TITLE
Remove the old style postSetup and setupEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,20 @@
 # dss-test
 
-Modern test framework for Maker repositories. Get up and running with MCD faster.
+Modern test framework for Maker repositories to get up and running with MCD faster. Extends `forge-std`.
 
 ## Getting Started
 
 First do `forge install makerdao/dss-test` (or dapp equivalent) in your newly setup repository.
 
-Sample test:
+Look at `src/tests/IntegrationTest.t.sol` for a bunch of examples.
 
-```
-pragma solidity 0.8.9;
-
-import "dss-test/DSSTest.sol";
-
-contract IntegrationTest is DSSTest {
-
-    using GodMode for *;
-
-    MCDUser myUser;
-
-    function setupEnv() internal virtual override returns (MCD) {
-        return autoDetectEnv();
-    }
-
-    function postSetup() internal virtual override {
-        myUser = mcd.newUser();
-    }
-
-    function test_give_tokens() public {
-        mcd.dai().setBalance(address(this), 100 ether);
-        assertEq(mcd.dai().balanceOf(address(this)), 100 ether);
-    }
-
-    function test_create_liquidation() public {
-        uint256 prevKicks = mcd.wethAClip().kicks();
-        myUser.createAuction(mcd.wethAJoin(), 100 ether);
-        assertEq(mcd.wethAClip().kicks(), prevKicks + 1);
-    }
-
-}
-```
-
-`setupEnv()` and `postSetup()` are hooks which allow you to configure both the environment you are in (mainnet, goerli, mocked) as well as an setup stuff that would normally go in `setUp()`. There is a special `GodMode` library which provides useful functions such as giving `auth` access to an arbitrary contract or setting token balances to any amount. You can also use `GodMode.vm()` to access all the underlying vm cheat codes.
+There is a special `GodMode` library which provides useful functions such as giving `auth` access to an arbitrary contract or setting token balances to any amount.
 
 ### MCD
 
-An `MCD` instance is mostly just for keeping a bundle of references to all the common mcd contracts. If you are doing integration testing this can be set by either instantiating `MCDMainnet` or `MCDGoerli` or just use `autoDetectEnv()` to do this automatically. `MCD` also provides some high level functions:
+An `DssInstance` is mostly just for keeping a bundle of references to all the common mcd contracts. If you are doing integration testing this can be loaded from the chainlog automatically with `MCD.loadFromChainlog()`. `MCD` also provides some high level functions:
 
- * `deployIlk(address join)` - This will deploy a new ilk to the vat along with standard liquidation and oracle components.
+ * `initIlk(...)` - This will deploy a new ilk to the `DssInstance` along with standard liquidation and oracle components.
 
 
 ### MCDUser

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ There is a special `GodMode` library which provides useful functions such as giv
 
 ### MCD
 
-An `DssInstance` is mostly just for keeping a bundle of references to all the common mcd contracts. If you are doing integration testing this can be loaded from the chainlog automatically with `MCD.loadFromChainlog()`. `MCD` also provides some high level functions:
+A `DssInstance` is mostly just for keeping a bundle of references to all the common mcd contracts. If you are doing integration testing this can be loaded from the chainlog automatically with `MCD.loadFromChainlog()`. `MCD` also provides some high level functions:
 
  * `initIlk(...)` - This will deploy a new ilk to the `DssInstance` along with standard liquidation and oracle components.
 

--- a/src/DSSTest.sol
+++ b/src/DSSTest.sol
@@ -54,21 +54,10 @@ abstract contract DSSTest is Test {
     event File(bytes32 indexed what, uint256 data);
     event File(bytes32 indexed what, address data);
 
-    function setUp() public virtual {
-        setupEnv();
-        postSetup();
-    }
-
     function readInput(string memory input) internal returns (string memory) {
         string memory root = vm.projectRoot();
         string memory chainInputFolder = string.concat("/script/input/", vm.toString(block.chainid), "/");
         return vm.readFile(string.concat(root, chainInputFolder, string.concat(input, ".json")));
-    }
-
-    function setupEnv() internal virtual {
-    }
-
-    function postSetup() internal virtual {
     }
 
     function assertRevert(address target, bytes memory data, string memory expectedMessage) internal {

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -50,7 +50,7 @@ contract IntegrationTest is DSSTest {
     OptimismDomain optimism;
     ArbitrumDomain arbitrum;
 
-    function setupEnv() internal virtual override {
+    function setUp() public virtual {
         config = readInput("integration");
 
         rootDomain = new RootDomain(config, "root");
@@ -58,9 +58,7 @@ contract IntegrationTest is DSSTest {
         rootDomain.loadDssFromChainlog();
         dss = rootDomain.dss(); // For ease of access
         ethA = dss.getIlk("ETH", "A");
-    }
 
-    function postSetup() internal virtual override {
         user1 = dss.newUser();
         user2 = dss.newUser();
         user3 = dss.newUser();


### PR DESCRIPTION
These functions were used previously when `DSSTest` was more strict, but this proved to be too hard to use, so it's completely flexible now. Since those PRs have been merged having these `postSetup` and `setupEnv` overridable functions doesn't make sense anymore, so I removed them.

Also, the README was totally out of date.