### PR TITLE
Add ScriptTools for common tasks in Scripts and Tests

### DIFF
--- a/src/DSSTest.sol
+++ b/src/DSSTest.sol
@@ -17,6 +17,7 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 
+import { ScriptTools } from "./ScriptTools.sol";
 import {
     GodMode,
     MCD,
@@ -54,10 +55,8 @@ abstract contract DSSTest is Test {
     event File(bytes32 indexed what, uint256 data);
     event File(bytes32 indexed what, address data);
 
-    function readInput(string memory input) internal returns (string memory) {
-        string memory root = vm.projectRoot();
-        string memory chainInputFolder = string.concat("/script/input/", vm.toString(block.chainid), "/");
-        return vm.readFile(string.concat(root, chainInputFolder, string.concat(input, ".json")));
+    function readInput(string memory input) internal view returns (string memory) {
+        return ScriptTools.readInput(input);
     }
 
     function assertRevert(address target, bytes memory data, string memory expectedMessage) internal {

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -77,17 +77,17 @@ library ScriptTools {
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
-     *         Writes contract to out/contract-exports.env
+     *         Writes contract to contract-exports.env
      */
     function exportContract(string memory name, address addr) internal {
-        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/out/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @notice Used to import contracts from previous exports.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
      *         Assume parent script has put environment variables into scope.
-     *         Run `source out/contract-exports.env` in parent script to get environment variables.
+     *         Run `source contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -53,17 +53,17 @@ library ScriptTools {
     /**
      * @dev Used to export important contracts to higher level deploy scripts.
      *      Note waiting on Foundry to have better primatives, but roll our own for now.
-     *      Writes contract to broadcast/contract-exports.env
+     *      Writes contract to out/contract-exports.env
      */
     function exportContract(string memory name, address addr) internal {
-        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/broadcast/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/out/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @dev Used to import contracts from previous exports.
      *      Note waiting on Foundry to have better primatives, but roll our own for now.
      *      Assume parent script has put environment variables into scope.
-     *      Run `source broadcast/contract-exports.env` in parent script to get environment variables.
+     *      Run `source out/contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -54,8 +54,17 @@ library ScriptTools {
      *      Note waiting on forge updates to support better exporting of contracts.
      *      For now we just log to stdout.
      */
-    function logContract(string memory name, address addr) internal view {
+    function exportContract(string memory name, address addr) internal view {
         console.log(string(abi.encodePacked("DSSTEST_EXPORT_", name, "=", vm.toString(addr))));
+    }
+
+    /**
+     * @dev Used to import contracts from previous exports.
+     *      Note waiting on forge updates to support better exporting of contracts.
+     *      For now we assume parent script has put environment variables into scope.
+     */
+    function importContract(string memory name) internal view returns (address addr) {
+        return vm.envAddress(string(abi.encodePacked("DSSTEST_EXPORT_", name)));
     }
 
     // Read config variable, but allow for an environment variable override

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -20,6 +20,8 @@ import { VmSafe } from "forge-std/Vm.sol";
 import { stdJson } from "forge-std/StdJson.sol";
 import { console } from "forge-std/console.sol";
 
+import { WardsAbstract } from "dss-interfaces/Interfaces.sol";
+
 /** 
  * @title Script Tools
  * @dev Contains opinionated tools used in scripts.
@@ -65,6 +67,13 @@ library ScriptTools {
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("DSSTEST_EXPORT_", name)));
+    }
+
+    function switchOwner(address base, address deployer, address newOwner) internal {
+        if (deployer == newOwner) return;
+        require(WardsAbstract(base).wards(deployer) == 1, "deployer-not-authed");
+        WardsAbstract(base).rely(newOwner);
+        WardsAbstract(base).deny(deployer);
     }
 
     // Read config variable, but allow for an environment variable override

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -18,7 +18,6 @@ pragma solidity >=0.8.0;
 
 import { VmSafe } from "forge-std/Vm.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-import { console } from "forge-std/console.sol";
 
 import { WardsAbstract } from "dss-interfaces/Interfaces.sol";
 
@@ -53,20 +52,21 @@ library ScriptTools {
 
     /**
      * @dev Used to export important contracts to higher level deploy scripts.
-     *      Note waiting on forge updates to support better exporting of contracts.
-     *      For now we just log to stdout.
+     *      Note waiting on Foundry to have better primatives, but roll our own for now.
+     *      Writes contract to broadcast/contract-exports.env
      */
-    function exportContract(string memory name, address addr) internal view {
-        console.log(string(abi.encodePacked("DSSTEST_EXPORT_", name, "=", vm.toString(addr))));
+    function exportContract(string memory name, address addr) internal {
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/broadcast/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @dev Used to import contracts from previous exports.
-     *      Note waiting on forge updates to support better exporting of contracts.
-     *      For now we assume parent script has put environment variables into scope.
+     *      Note waiting on Foundry to have better primatives, but roll our own for now.
+     *      Assume parent script has put environment variables into scope.
+     *      Run `source broadcast/contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
-        return vm.envAddress(string(abi.encodePacked("DSSTEST_EXPORT_", name)));
+        return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));
     }
 
     function switchOwner(address base, address deployer, address newOwner) internal {

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017 DappHub, LLC
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.8.0;
+
+import { VmSafe } from "forge-std/Vm.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+/** 
+ * @title Script Tools
+ * @dev Contains opinionated tools used in scripts.
+ */
+library ScriptTools {
+
+    VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
+    
+    string internal constant DEFAULT_DELIMITER = ",";
+    string internal constant DELIMITER_OVERRIDE = "DSSTEST_ARRAY_DELIMITER";
+
+    function readInput(string memory input) internal view returns (string memory) {
+        string memory root = vm.projectRoot();
+        string memory chainInputFolder = string(abi.encodePacked("/script/input/", vm.toString(block.chainid), "/"));
+        return vm.readFile(string(abi.encodePacked(root, chainInputFolder, input, ".json")));
+    }
+
+    /// @dev It's common to define strings as bytes32 (such as for ilks)
+    function stringToBytes32(string memory source) internal pure returns (bytes32 result) {
+        bytes memory tempEmptyStringTest = bytes(source);
+        if (tempEmptyStringTest.length == 0) {
+            return 0x0;
+        }
+
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    /**
+     * @dev Used to export important contracts to higher level deploy scripts.
+     *      Note waiting on forge updates to support better exporting of contracts.
+     *      For now we just log to stdout.
+     */
+    function logContract(string memory name, address addr) internal view {
+        console.log(string(abi.encodePacked("DSSTEST_EXPORT_", name, "=", vm.toString(addr))));
+    }
+
+    // Read config variable, but allow for an environment variable override
+
+    function readUint(string memory json, string memory key, string memory envKey) internal returns (uint256) {
+        return vm.envOr(envKey, stdJson.readUint(json, key));
+    }
+
+    function readUintArray(string memory json, string memory key, string memory envKey) internal returns (uint256[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readUintArray(json, key));
+    }
+
+    function readInt(string memory json, string memory key, string memory envKey) internal returns (int256) {
+        return vm.envOr(envKey, stdJson.readInt(json, key));
+    }
+
+    function readIntArray(string memory json, string memory key, string memory envKey) internal returns (int256[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readIntArray(json, key));
+    }
+
+    function readBytes32(string memory json, string memory key, string memory envKey) internal returns (bytes32) {
+        return vm.envOr(envKey, stdJson.readBytes32(json, key));
+    }
+
+    function readBytes32Array(string memory json, string memory key, string memory envKey) internal returns (bytes32[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readBytes32Array(json, key));
+    }
+
+    function readString(string memory json, string memory key, string memory envKey) internal returns (string memory) {
+        return vm.envOr(envKey, stdJson.readString(json, key));
+    }
+
+    function readStringArray(string memory json, string memory key, string memory envKey) internal returns (string[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readStringArray(json, key));
+    }
+
+    function readAddress(string memory json, string memory key, string memory envKey) internal returns (address) {
+        return vm.envOr(envKey, stdJson.readAddress(json, key));
+    }
+
+    function readAddressArray(string memory json, string memory key, string memory envKey) internal returns (address[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readAddressArray(json, key));
+    }
+
+    function readBool(string memory json, string memory key, string memory envKey) internal returns (bool) {
+        return vm.envOr(envKey, stdJson.readBool(json, key));
+    }
+
+    function readBoolArray(string memory json, string memory key, string memory envKey) internal returns (bool[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readBoolArray(json, key));
+    }
+
+    function readBytes(string memory json, string memory key, string memory envKey) internal returns (bytes memory) {
+        return vm.envOr(envKey, stdJson.readBytes(json, key));
+    }
+
+    function readBytesArray(string memory json, string memory key, string memory envKey) internal returns (bytes[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readBytesArray(json, key));
+    }
+
+}

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -70,6 +70,10 @@ library ScriptTools {
         return string(result);
     }
 
+    function eq(string memory a, string memory b) internal pure returns (bool) {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
+    }
+
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -77,17 +77,17 @@ library ScriptTools {
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
-     *         Writes contract to contract-exports.env
+     *         Writes contract to out/contract-exports.env
      */
     function exportContract(string memory name, address addr) internal {
-        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/out/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @notice Used to import contracts from previous exports.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
      *         Assume parent script has put environment variables into scope.
-     *         Run `source contract-exports.env` in parent script to get environment variables.
+     *         Run `source out/contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -41,23 +41,23 @@ contract Domain {
         vm.makePersistent(address(this));
     }
 
-    function readConfigString(string memory key) public returns (string memory) {
+    function readConfigString(string memory key) public view returns (string memory) {
         return config.readString(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigAddress(string memory key) public returns (address) {
+    function readConfigAddress(string memory key) public view returns (address) {
         return config.readAddress(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigUint(string memory key) public returns (uint256) {
+    function readConfigUint(string memory key) public view returns (uint256) {
         return config.readUint(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigInt(string memory key) public returns (int256) {
+    function readConfigInt(string memory key) public view returns (int256) {
         return config.readInt(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigBytes32(string memory key) public returns (bytes32) {
+    function readConfigBytes32(string memory key) public view returns (bytes32) {
         return config.readBytes32(string.concat(".domains.", name, ".", key));
     }
 
@@ -69,7 +69,7 @@ contract Domain {
         return out;
     }
 
-    function readConfigBytes32FromString(string memory key) public returns (bytes32) {
+    function readConfigBytes32FromString(string memory key) public view returns (bytes32) {
         return bytesToBytes32(bytes(readConfigString(key)));
     }
 

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -40,4 +40,12 @@ contract ScriptToolTest is DSSTest {
         assertEq(ScriptTools.ilkToChainlogFormat(bytes32("DIRECT-AAVEV2-DAI")), "DIRECT_AAVEV2_DAI");
     }
 
+    function test_eq() public {
+        assertTrue(ScriptTools.eq("A", "A"));
+    }
+
+    function test_not_eq() public {
+        assertTrue(!ScriptTools.eq("A", "B"));
+    }
+
 }

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.8.0;
+
+import "../DSSTest.sol";
+import "../ScriptTools.sol";
+
+contract ScriptToolTest is DSSTest {
+
+    function test_stringToBytes32() public {
+        assertEq(ScriptTools.stringToBytes32("test"),  bytes32("test"));
+    }
+
+    function test_stringToBytes32_empty() public {
+        assertEq(ScriptTools.stringToBytes32(""),  bytes32(""));
+    }
+
+    function test_ilkToChainlogFormat() public {
+        assertEq(ScriptTools.ilkToChainlogFormat(bytes32("ETH-A")), "ETH_A");
+    }
+
+    function test_ilkToChainlogFormat_empty() public {
+        assertEq(ScriptTools.ilkToChainlogFormat(bytes32("")), "");
+    }
+
+    function test_ilkToChainlogFormat_multiple() public {
+        assertEq(ScriptTools.ilkToChainlogFormat(bytes32("DIRECT-AAVEV2-DAI")), "DIRECT_AAVEV2_DAI");
+    }
+
+}


### PR DESCRIPTION
This mostly involves things like standard locations for json files as well as allowing environment variable overrides for json config defaults.

Updated `forge-std` as it contains new optional environment variables.

Note: The `ScriptTools.importContract/exportContract(...)` is not great as it requires the executing custom logic in the bash script to expose the variables. Am requesting a higher level deploy feature here along with another guy: https://github.com/foundry-rs/foundry/issues/3911