### PR TITLE
Refactor Multichain

### DIFF
--- a/script/input/5/integration.json
+++ b/script/input/5/integration.json
@@ -1,14 +1,14 @@
 {
     "domains": {
-        "mainnet": {
+        "goerli": {
             "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F"
         },
-        "optimism": {
-            "l1Messenger": "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1",
+        "optimism_goerli": {
+            "l1Messenger": "0x5086d1eEF304eb5284A0f6720f79403b4e9bE294",
             "l2Messenger": "0x4200000000000000000000000000000000000007"
         },
-        "arbitrum_one": {
-            "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
+        "arbitrum_one_goerli": {
+            "inbox": "0x6BEbC4925716945D46F0Ec336D5C2564F419682C",
             "arbSys": "0x0000000000000000000000000000000000000064"
         }
     }

--- a/src/DSSTest.sol
+++ b/src/DSSTest.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2021 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -55,8 +55,23 @@ abstract contract DSSTest is Test {
     event File(bytes32 indexed what, uint256 data);
     event File(bytes32 indexed what, address data);
 
-    function readInput(string memory input) internal view returns (string memory) {
+    function readInput(string memory input) internal returns (string memory) {
         return ScriptTools.readInput(input);
+    }
+
+    /**
+     * @notice Takes the root chain into account when finding relative chains.
+     *         Ex. if the root chain id is 5 then "optimism" will convert to "optimism_goerli", etc
+     */
+    function getRelativeChain(string memory name) internal returns (StdChains.Chain memory) {
+        if (ScriptTools.getRootChainId() == 5) {
+            // Do Goerli translations
+            if (ScriptTools.eq(name, "mainnet")) name = "goerli";
+            else if (ScriptTools.eq(name, "optimism")) name = "optimism_goerli";
+            else if (ScriptTools.eq(name, "arbitrum_one")) name = "arbitrum_one_goerli";
+        }
+
+        return getChain(name);
     }
 
     function assertRevert(address target, bytes memory data, string memory expectedMessage) internal {

--- a/src/DSSTest.sol
+++ b/src/DSSTest.sol
@@ -17,6 +17,7 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 
+import { ScriptTools } from "./ScriptTools.sol";
 import {
     GodMode,
     MCD,
@@ -54,10 +55,8 @@ abstract contract DSSTest is Test {
     event File(bytes32 indexed what, uint256 data);
     event File(bytes32 indexed what, address data);
 
-    function readInput(string memory input) internal returns (string memory) {
-        string memory root = vm.projectRoot();
-        string memory chainInputFolder = string.concat("/script/input/", vm.toString(block.chainid), "/");
-        return vm.readFile(string.concat(root, chainInputFolder, string.concat(input, ".json")));
+    function readInput(string memory input) internal view returns (string memory) {
+        return ScriptTools.readInput(input);
     }
 
     function assertRevert(address target, bytes memory data, string memory expectedMessage) internal {

--- a/src/GodMode.sol
+++ b/src/GodMode.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2021 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/MCD.sol
+++ b/src/MCD.sol
@@ -1,6 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2017 DappHub, LLC
-// Copyright (C) 2021 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/MCDUser.sol
+++ b/src/MCDUser.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2021 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -77,17 +77,17 @@ library ScriptTools {
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
-     *         Writes contract to out/contract-exports.env
+     *         Writes contract to contract-exports.env
      */
     function exportContract(string memory name, address addr) internal {
-        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/out/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @notice Used to import contracts from previous exports.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
      *         Assume parent script has put environment variables into scope.
-     *         Run `source out/contract-exports.env` in parent script to get environment variables.
+     *         Run `source contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -53,17 +53,17 @@ library ScriptTools {
     /**
      * @dev Used to export important contracts to higher level deploy scripts.
      *      Note waiting on Foundry to have better primatives, but roll our own for now.
-     *      Writes contract to broadcast/contract-exports.env
+     *      Writes contract to out/contract-exports.env
      */
     function exportContract(string memory name, address addr) internal {
-        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/broadcast/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/out/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @dev Used to import contracts from previous exports.
      *      Note waiting on Foundry to have better primatives, but roll our own for now.
      *      Assume parent script has put environment variables into scope.
-     *      Run `source broadcast/contract-exports.env` in parent script to get environment variables.
+     *      Run `source out/contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -31,8 +31,9 @@ library ScriptTools {
     string internal constant DEFAULT_DELIMITER = ",";
     string internal constant DELIMITER_OVERRIDE = "DSSTEST_ARRAY_DELIMITER";
 
-    function getRootChainId() internal returns (uint256) {
-        return vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
+    function getRootChainId() internal returns (uint256 chaindId) {
+        chaindId vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
+        if (chaindId == 0) chaindId = 1;
     }
 
     function readInput(string memory input) internal returns (string memory) {

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -1,6 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2017 DappHub, LLC
-// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -32,9 +31,13 @@ library ScriptTools {
     string internal constant DEFAULT_DELIMITER = ",";
     string internal constant DELIMITER_OVERRIDE = "DSSTEST_ARRAY_DELIMITER";
 
-    function readInput(string memory input) internal view returns (string memory) {
+    function getRootChainId() internal returns (uint256) {
+        return vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
+    }
+
+    function readInput(string memory input) internal returns (string memory) {
         string memory root = vm.projectRoot();
-        string memory chainInputFolder = string(abi.encodePacked("/script/input/", vm.toString(block.chainid), "/"));
+        string memory chainInputFolder = string(abi.encodePacked("/script/input/", vm.toString(getRootChainId()), "/"));
         return vm.readFile(string(abi.encodePacked(root, chainInputFolder, input, ".json")));
     }
 

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -54,8 +54,17 @@ library ScriptTools {
      *      Note waiting on forge updates to support better exporting of contracts.
      *      For now we just log to stdout.
      */
-    function logContract(string memory name, address addr) internal view {
+    function exportContract(string memory name, address addr) internal view {
         console.log(string(abi.encodePacked("DSSTEST_EXPORT_", name, "=", vm.toString(addr))));
+    }
+
+    /**
+     * @dev Used to import contracts from previous exports.
+     *      Note waiting on forge updates to support better exporting of contracts.
+     *      For now we assume parent script has put environment variables into scope.
+     */
+    function importContract(string memory name) internal view returns (address addr) {
+        return vm.envAddress(string(abi.encodePacked("DSSTEST_EXPORT_", name)));
     }
 
     // Read config variable, but allow for an environment variable override

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -20,6 +20,8 @@ import { VmSafe } from "forge-std/Vm.sol";
 import { stdJson } from "forge-std/StdJson.sol";
 import { console } from "forge-std/console.sol";
 
+import { WardsAbstract } from "dss-interfaces/Interfaces.sol";
+
 /** 
  * @title Script Tools
  * @dev Contains opinionated tools used in scripts.
@@ -65,6 +67,13 @@ library ScriptTools {
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("DSSTEST_EXPORT_", name)));
+    }
+
+    function switchOwner(address base, address deployer, address newOwner) internal {
+        if (deployer == newOwner) return;
+        require(WardsAbstract(base).wards(deployer) == 1, "deployer-not-authed");
+        WardsAbstract(base).rely(newOwner);
+        WardsAbstract(base).deny(deployer);
     }
 
     // Read config variable, but allow for an environment variable override

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -18,7 +18,6 @@ pragma solidity >=0.8.0;
 
 import { VmSafe } from "forge-std/Vm.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-import { console } from "forge-std/console.sol";
 
 import { WardsAbstract } from "dss-interfaces/Interfaces.sol";
 
@@ -53,20 +52,21 @@ library ScriptTools {
 
     /**
      * @dev Used to export important contracts to higher level deploy scripts.
-     *      Note waiting on forge updates to support better exporting of contracts.
-     *      For now we just log to stdout.
+     *      Note waiting on Foundry to have better primatives, but roll our own for now.
+     *      Writes contract to broadcast/contract-exports.env
      */
-    function exportContract(string memory name, address addr) internal view {
-        console.log(string(abi.encodePacked("DSSTEST_EXPORT_", name, "=", vm.toString(addr))));
+    function exportContract(string memory name, address addr) internal {
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/broadcast/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @dev Used to import contracts from previous exports.
-     *      Note waiting on forge updates to support better exporting of contracts.
-     *      For now we assume parent script has put environment variables into scope.
+     *      Note waiting on Foundry to have better primatives, but roll our own for now.
+     *      Assume parent script has put environment variables into scope.
+     *      Run `source broadcast/contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
-        return vm.envAddress(string(abi.encodePacked("DSSTEST_EXPORT_", name)));
+        return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));
     }
 
     function switchOwner(address base, address deployer, address newOwner) internal {

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017 DappHub, LLC
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.8.0;
+
+import { VmSafe } from "forge-std/Vm.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { console } from "forge-std/console.sol";
+
+/** 
+ * @title Script Tools
+ * @dev Contains opinionated tools used in scripts.
+ */
+library ScriptTools {
+
+    VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
+    
+    string internal constant DEFAULT_DELIMITER = ",";
+    string internal constant DELIMITER_OVERRIDE = "DSSTEST_ARRAY_DELIMITER";
+
+    function readInput(string memory input) internal view returns (string memory) {
+        string memory root = vm.projectRoot();
+        string memory chainInputFolder = string(abi.encodePacked("/script/input/", vm.toString(block.chainid), "/"));
+        return vm.readFile(string(abi.encodePacked(root, chainInputFolder, input, ".json")));
+    }
+
+    /// @dev It's common to define strings as bytes32 (such as for ilks)
+    function stringToBytes32(string memory source) internal pure returns (bytes32 result) {
+        bytes memory tempEmptyStringTest = bytes(source);
+        if (tempEmptyStringTest.length == 0) {
+            return 0x0;
+        }
+
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    /**
+     * @dev Used to export important contracts to higher level deploy scripts.
+     *      Note waiting on forge updates to support better exporting of contracts.
+     *      For now we just log to stdout.
+     */
+    function logContract(string memory name, address addr) internal view {
+        console.log(string(abi.encodePacked("DSSTEST_EXPORT_", name, "=", vm.toString(addr))));
+    }
+
+    // Read config variable, but allow for an environment variable override
+
+    function readUint(string memory json, string memory key, string memory envKey) internal returns (uint256) {
+        return vm.envOr(envKey, stdJson.readUint(json, key));
+    }
+
+    function readUintArray(string memory json, string memory key, string memory envKey) internal returns (uint256[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readUintArray(json, key));
+    }
+
+    function readInt(string memory json, string memory key, string memory envKey) internal returns (int256) {
+        return vm.envOr(envKey, stdJson.readInt(json, key));
+    }
+
+    function readIntArray(string memory json, string memory key, string memory envKey) internal returns (int256[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readIntArray(json, key));
+    }
+
+    function readBytes32(string memory json, string memory key, string memory envKey) internal returns (bytes32) {
+        return vm.envOr(envKey, stdJson.readBytes32(json, key));
+    }
+
+    function readBytes32Array(string memory json, string memory key, string memory envKey) internal returns (bytes32[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readBytes32Array(json, key));
+    }
+
+    function readString(string memory json, string memory key, string memory envKey) internal returns (string memory) {
+        return vm.envOr(envKey, stdJson.readString(json, key));
+    }
+
+    function readStringArray(string memory json, string memory key, string memory envKey) internal returns (string[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readStringArray(json, key));
+    }
+
+    function readAddress(string memory json, string memory key, string memory envKey) internal returns (address) {
+        return vm.envOr(envKey, stdJson.readAddress(json, key));
+    }
+
+    function readAddressArray(string memory json, string memory key, string memory envKey) internal returns (address[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readAddressArray(json, key));
+    }
+
+    function readBool(string memory json, string memory key, string memory envKey) internal returns (bool) {
+        return vm.envOr(envKey, stdJson.readBool(json, key));
+    }
+
+    function readBoolArray(string memory json, string memory key, string memory envKey) internal returns (bool[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readBoolArray(json, key));
+    }
+
+    function readBytes(string memory json, string memory key, string memory envKey) internal returns (bytes memory) {
+        return vm.envOr(envKey, stdJson.readBytes(json, key));
+    }
+
+    function readBytesArray(string memory json, string memory key, string memory envKey) internal returns (bytes[] memory) {
+        return vm.envOr(envKey, vm.envOr(DELIMITER_OVERRIDE, DEFAULT_DELIMITER), stdJson.readBytesArray(json, key));
+    }
+
+}

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -32,7 +32,7 @@ library ScriptTools {
     string internal constant DELIMITER_OVERRIDE = "DSSTEST_ARRAY_DELIMITER";
 
     function getRootChainId() internal returns (uint256 chaindId) {
-        chaindId vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
+        chaindId = vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
         if (chaindId == 0) chaindId = 1;
     }
 

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -70,6 +70,10 @@ library ScriptTools {
         return string(result);
     }
 
+    function eq(string memory a, string memory b) internal pure returns (bool) {
+        return keccak256(bytes(a)) == keccak256(bytes(b));
+    }
+
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -77,17 +77,17 @@ library ScriptTools {
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
-     *         Writes contract to contract-exports.env
+     *         Writes contract to out/contract-exports.env
      */
     function exportContract(string memory name, address addr) internal {
-        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
+        vm.writeLine(string(abi.encodePacked(vm.projectRoot(), "/out/contract-exports.env")), string(abi.encodePacked("export FOUNDRY_EXPORT_", name, "=", vm.toString(addr))));
     }
 
     /**
      * @notice Used to import contracts from previous exports.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
      *         Assume parent script has put environment variables into scope.
-     *         Run `source contract-exports.env` in parent script to get environment variables.
+     *         Run `source out/contract-exports.env` in parent script to get environment variables.
      */
     function importContract(string memory name) internal view returns (address addr) {
         return vm.envAddress(string(abi.encodePacked("FOUNDRY_EXPORT_", name)));

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -31,9 +31,8 @@ library ScriptTools {
     string internal constant DEFAULT_DELIMITER = ",";
     string internal constant DELIMITER_OVERRIDE = "DSSTEST_ARRAY_DELIMITER";
 
-    function getRootChainId() internal returns (uint256 chaindId) {
-        chaindId = vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
-        if (chaindId == 0) chaindId = 1;
+    function getRootChainId() internal returns (uint256) {
+        return vm.envOr("FOUNDRY_ROOT_CHAINID", uint256(1));
     }
 
     function readInput(string memory input) internal returns (string memory) {

--- a/src/domains/ArbitrumDomain.sol
+++ b/src/domains/ArbitrumDomain.sol
@@ -17,7 +17,8 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Vm.sol";
 
-import { Domain, BridgedDomain, StdChains } from "./BridgedDomain.sol";
+import { Domain, BridgedDomain } from "./BridgedDomain.sol";
+import { StdChains } from "forge-std/StdChains.sol";
 
 interface InboxLike {
     function bridge() external view returns (address);

--- a/src/domains/ArbitrumDomain.sol
+++ b/src/domains/ArbitrumDomain.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -17,7 +17,7 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Vm.sol";
 
-import { Domain, BridgedDomain } from "./BridgedDomain.sol";
+import { Domain, BridgedDomain, StdChains } from "./BridgedDomain.sol";
 
 interface InboxLike {
     function bridge() external view returns (address);
@@ -55,7 +55,7 @@ contract ArbitrumDomain is BridgedDomain {
     bytes32 constant MESSAGE_DELIVERED_TOPIC = keccak256("MessageDelivered(uint256,bytes32,address,uint8,address,bytes32,uint256,uint64)");
     bytes32 constant SEND_TO_L1_TOPIC = keccak256("SendTxToL1(address,address,bytes)");
 
-    constructor(string memory _config, string memory _name, Domain _hostDomain) Domain(_config, _name) BridgedDomain(_hostDomain) {
+    constructor(string memory _config, StdChains.Chain memory _chain, Domain _hostDomain) Domain(_config, _chain) BridgedDomain(_hostDomain) {
         inbox = InboxLike(readConfigAddress("inbox"));
         arbSys = readConfigAddress("arbSys");
         bridge = BridgeLike(inbox.bridge());

--- a/src/domains/BridgedDomain.sol
+++ b/src/domains/BridgedDomain.sol
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import { Domain, StdChains } from "./Domain.sol";
+import { Domain } from "./Domain.sol";
 
 abstract contract BridgedDomain is Domain {
 

--- a/src/domains/BridgedDomain.sol
+++ b/src/domains/BridgedDomain.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import { Domain } from "./Domain.sol";
+import { Domain, StdChains } from "./Domain.sol";
 
 abstract contract BridgedDomain is Domain {
 

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -15,50 +15,48 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import {stdJson} from "forge-std/StdJson.sol";
-import {ChainlogAbstract} from "dss-interfaces/Interfaces.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { StdChains } from "forge-std/StdChains.sol";
+import { Vm } from "forge-std/Vm.sol";
 
-import {MCD,DssInstance} from "../MCD.sol";
-import {GodMode,Vm} from "../GodMode.sol";
+import { MCD, DssInstance } from "../MCD.sol";
 
 contract Domain {
 
     using stdJson for string;
 
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
     string public config;
-    string public name;
+    StdChains.Chain private _details;
     DssInstance private _dss;
-    Vm public vm;
     uint256 public forkId;
 
-    constructor(string memory _config, string memory _name) {
+    constructor(string memory _config, StdChains.Chain memory _chain) {
         config = _config;
-        name = _name;
-        vm = GodMode.vm();
-        string memory rpc = vm.envString(readConfigString("rpc"));
-        if (bytes(rpc).length == 0) revert(string.concat("Environment variable '", rpc, "' is not defined."));
-        forkId = vm.createFork(rpc);
+        _details = _chain;
+        forkId = vm.createFork(_chain.rpcUrl);
         vm.makePersistent(address(this));
     }
 
     function readConfigString(string memory key) public view returns (string memory) {
-        return config.readString(string.concat(".domains.", name, ".", key));
+        return config.readString(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function readConfigAddress(string memory key) public view returns (address) {
-        return config.readAddress(string.concat(".domains.", name, ".", key));
+        return config.readAddress(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function readConfigUint(string memory key) public view returns (uint256) {
-        return config.readUint(string.concat(".domains.", name, ".", key));
+        return config.readUint(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function readConfigInt(string memory key) public view returns (int256) {
-        return config.readInt(string.concat(".domains.", name, ".", key));
+        return config.readInt(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function readConfigBytes32(string memory key) public view returns (bytes32) {
-        return config.readBytes32(string.concat(".domains.", name, ".", key));
+        return config.readBytes32(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function bytesToBytes32(bytes memory b) private pure returns (bytes32) {
@@ -80,9 +78,17 @@ contract Domain {
     function dss() public view returns (DssInstance memory) {
         return _dss;
     }
+
+    function details() public view returns (StdChains.Chain memory) {
+        return _details;
+    }
     
     function selectFork() public {
         vm.selectFork(forkId);
+    }
+    
+    function rollFork(uint256 blocknum) public {
+        vm.rollFork(forkId, blocknum);
     }
 
 }

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -41,23 +41,23 @@ contract Domain {
         vm.makePersistent(address(this));
     }
 
-    function readConfigString(string memory key) public returns (string memory) {
+    function readConfigString(string memory key) public view returns (string memory) {
         return config.readString(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigAddress(string memory key) public returns (address) {
+    function readConfigAddress(string memory key) public view returns (address) {
         return config.readAddress(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigUint(string memory key) public returns (uint256) {
+    function readConfigUint(string memory key) public view returns (uint256) {
         return config.readUint(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigInt(string memory key) public returns (int256) {
+    function readConfigInt(string memory key) public view returns (int256) {
         return config.readInt(string.concat(".domains.", name, ".", key));
     }
 
-    function readConfigBytes32(string memory key) public returns (bytes32) {
+    function readConfigBytes32(string memory key) public view returns (bytes32) {
         return config.readBytes32(string.concat(".domains.", name, ".", key));
     }
 
@@ -69,7 +69,7 @@ contract Domain {
         return out;
     }
 
-    function readConfigBytes32FromString(string memory key) public returns (bytes32) {
+    function readConfigBytes32FromString(string memory key) public view returns (bytes32) {
         return bytesToBytes32(bytes(readConfigString(key)));
     }
 

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -85,6 +85,7 @@ contract Domain {
     
     function selectFork() public {
         vm.selectFork(forkId);
+        require(block.chainid == _details.chainId, string(abi.encodePacked(_details.chainAlias, " is pointing to the wrong RPC endpoint '", _details.rpcUrl, "'")));
     }
     
     function rollFork(uint256 blocknum) public {

--- a/src/domains/OptimismDomain.sol
+++ b/src/domains/OptimismDomain.sol
@@ -17,7 +17,8 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Vm.sol";
 
-import { Domain, BridgedDomain, StdChains } from "./BridgedDomain.sol";
+import { Domain, BridgedDomain } from "./BridgedDomain.sol";
+import { StdChains } from "forge-std/StdChains.sol";
 
 interface MessengerLike {
     function relayMessage(

--- a/src/domains/OptimismDomain.sol
+++ b/src/domains/OptimismDomain.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -17,7 +17,7 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Vm.sol";
 
-import { Domain, BridgedDomain } from "./BridgedDomain.sol";
+import { Domain, BridgedDomain, StdChains } from "./BridgedDomain.sol";
 
 interface MessengerLike {
     function relayMessage(
@@ -36,7 +36,7 @@ contract OptimismDomain is BridgedDomain {
     bytes32 constant SENT_MESSAGE_TOPIC = keccak256("SentMessage(address,address,bytes,uint256,uint256)");
     uint160 constant OFFSET = uint160(0x1111000000000000000000000000000000001111);
 
-    constructor(string memory _config, string memory _name, Domain _hostDomain) Domain(_config, _name) BridgedDomain(_hostDomain) {
+    constructor(string memory _config, StdChains.Chain memory _chain, Domain _hostDomain) Domain(_config, _chain) BridgedDomain(_hostDomain) {
         l1Messenger = MessengerLike(readConfigAddress("l1Messenger"));
         l2Messenger = MessengerLike(readConfigAddress("l2Messenger"));
         vm.recordLogs();

--- a/src/domains/RootDomain.sol
+++ b/src/domains/RootDomain.sol
@@ -15,7 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import { Domain, StdChains } from "./Domain.sol";
+import { Domain } from "./Domain.sol";
+import { StdChains } from "forge-std/StdChains.sol";
 
 contract RootDomain is Domain {
 

--- a/src/domains/RootDomain.sol
+++ b/src/domains/RootDomain.sol
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import {Domain} from "./Domain.sol";
+import { Domain, StdChains } from "./Domain.sol";
 
 contract RootDomain is Domain {
 
-    constructor(string memory _config, string memory _name) Domain(_config, _name) {
+    constructor(string memory _config, StdChains.Chain memory _chain) Domain(_config, _chain) {
     }
     
 }

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -40,4 +40,12 @@ contract ScriptToolTest is DSSTest {
         assertEq(ScriptTools.ilkToChainlogFormat(bytes32("DIRECT-AAVEV2-DAI")), "DIRECT_AAVEV2_DAI");
     }
 
+    function test_eq() public {
+        assertTrue(ScriptTools.eq("A", "A"));
+    }
+
+    function test_not_eq() public {
+        assertTrue(!ScriptTools.eq("A", "B"));
+    }
+
 }

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.8.0;
+
+import "../DSSTest.sol";
+import "../ScriptTools.sol";
+
+contract ScriptToolTest is DSSTest {
+
+    function test_stringToBytes32() public {
+        assertEq(ScriptTools.stringToBytes32("test"),  bytes32("test"));
+    }
+
+    function test_stringToBytes32_empty() public {
+        assertEq(ScriptTools.stringToBytes32(""),  bytes32(""));
+    }
+
+    function test_ilkToChainlogFormat() public {
+        assertEq(ScriptTools.ilkToChainlogFormat(bytes32("ETH-A")), "ETH_A");
+    }
+
+    function test_ilkToChainlogFormat_empty() public {
+        assertEq(ScriptTools.ilkToChainlogFormat(bytes32("")), "");
+    }
+
+    function test_ilkToChainlogFormat_multiple() public {
+        assertEq(ScriptTools.ilkToChainlogFormat(bytes32("DIRECT-AAVEV2-DAI")), "DIRECT_AAVEV2_DAI");
+    }
+
+}

--- a/test.sh
+++ b/test.sh
@@ -2,12 +2,14 @@
 set -e
 
 [[ $ETH_RPC_URL  ]] || { echo "Please set an ETH_RPC_URL"; exit 1; }
-
-export FOUNDRY_ROOT_CHAINID="$(cast chain-id)"
+if [ -z "$FOUNDRY_ROOT_CHAINID" ]; then
+  export FOUNDRY_ROOT_CHAINID="$(cast chain-id)"
+fi
 if [ "$FOUNDRY_ROOT_CHAINID" != "1" ] && [ "$FOUNDRY_ROOT_CHAINID" != "5" ]; then
-  echo "Invalid chainid of $FOUNDRY_ROOT_CHAINID. Please set your forking environment via ETH_RPC_URL."
+  echo "Invalid chainid of $FOUNDRY_ROOT_CHAINID. Please set your forking environment via ETH_RPC_URL or manually by defining FOUNDRY_ROOT_CHAINID."
   exit
 fi
+
 if [[ -z "$1" ]]; then
   forge test
 else

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
+[[ $ETH_RPC_URL  ]] || { echo "Please set an ETH_RPC_URL"; exit 1; }
+
 export FOUNDRY_ROOT_CHAINID="$(cast chain-id)"
 if [ "$FOUNDRY_ROOT_CHAINID" != "1" ] && [ "$FOUNDRY_ROOT_CHAINID" != "5" ]; then
   echo "Invalid chainid of $FOUNDRY_ROOT_CHAINID. Please set your forking environment via ETH_RPC_URL."
   exit
 fi
-
 if [[ -z "$1" ]]; then
   forge test
 else

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+export FOUNDRY_ROOT_CHAINID="$(cast chain-id)"
+
 if [[ -z "$1" ]]; then
-  forge test --rpc-url "$ETH_RPC_URL"
+  forge test
 else
-  forge test --rpc-url "$ETH_RPC_URL" --match "$1" -vvv
+  forge test --match "$1" -vvvvv
 fi

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-[[ $ETH_RPC_URL  ]] || { echo "Please set an ETH_RPC_URL"; exit 1; }
-if [ -z "$FOUNDRY_ROOT_CHAINID" ]; then
+if [[ -z "$FOUNDRY_ROOT_CHAINID" ]]; then
+  [[ $ETH_RPC_URL  ]] || { echo "Please set an ETH_RPC_URL"; exit 1; }
   export FOUNDRY_ROOT_CHAINID="$(cast chain-id)"
 fi
 if [ "$FOUNDRY_ROOT_CHAINID" != "1" ] && [ "$FOUNDRY_ROOT_CHAINID" != "5" ]; then

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,10 @@
 set -e
 
 export FOUNDRY_ROOT_CHAINID="$(cast chain-id)"
+if [ "$FOUNDRY_ROOT_CHAINID" != "1" ] && [ "$FOUNDRY_ROOT_CHAINID" != "5" ]; then
+  echo "Invalid chainid of $FOUNDRY_ROOT_CHAINID. Please set your forking environment via ETH_RPC_URL."
+  exit
+fi
 
 if [[ -z "$1" ]]; then
   forge test


### PR DESCRIPTION
Refactored the multichain stuff to start using the `StdChains` addition to `forge-std` which defines default rpc endpoints.

I've included a PR https://github.com/foundry-rs/forge-std/pull/268 which allows environment variable overrides. This will allow devs to set global bash profiles (with potentially private api keys) such as:

```
# RPC Endpoints
export RPC_URL_MAINNET=https://eth-mainnet.alchemyapi.io/v2/XXXX
export RPC_URL_OPTIMISM=https://opt-mainnet.g.alchemy.com/v2/XXXX
export RPC_URL_ARBITRUM_ONE=https://arb-goerli.g.alchemy.com/v2/XXXX
export RPC_URL_ARBITRUM_NOVA=https://nova.arbitrum.io/rpc

export RPC_URL_GOERLI=https://eth-goerli.g.alchemy.com/v2/XXXX
export RPC_URL_OPTIMISM_GOERLI=https://opt-goerli.g.alchemy.com/v2/XXXX
export RPC_URL_ARBITRUM_ONE_GOERLI=https://arb-goerli.g.alchemy.com/v2/XXXX
export RPC_URL_ZKSYNC_GOERLI=https://zksync2-testnet.zksync.dev
```

and have the test scripts automatically pick things up.

Another change is this removes defining forks as a cli arg. It is up to the test script to manage forking.

I've also added relative mappings to allow easy anchoring on either `mainnet` or `goerli`. This will allow you to say things such as fetch me the optimism chain and have it either pick `optimism` or `optimism_goerli` respectively depending on whether your root is mainnet or goerli respectively.

Selecting the root fork is done by setting `FOUNDRY_ROOT_CHAINID` to be either 1 or 5.

Note: some of the integration tests are failing, but doesn't have to do with this PR I don't think. Can fix in another one.