### PR TITLE
DSSTest => DssTest

### DIFF
--- a/src/DssTest.sol
+++ b/src/DssTest.sol
@@ -37,7 +37,7 @@ interface FileLike is AuthLike {
     function file(bytes32, address) external;
 }
 
-abstract contract DSSTest is Test {
+abstract contract DssTest is Test {
 
     uint256 constant WAD = 10 ** 18;
     uint256 constant RAY = 10 ** 27;

--- a/src/tests/AuthUnitTest.t.sol
+++ b/src/tests/AuthUnitTest.t.sol
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import "../DSSTest.sol";
+import "../DssTest.sol";
 
 contract ValidAuthContract {
     event Rely(address indexed usr);
@@ -90,7 +90,7 @@ contract InvalidAuthContractDeny3 {
     constructor() { wards[msg.sender] = 1; emit Rely(msg.sender); }
 }
 
-contract AuthUnitTest is DSSTest {
+contract AuthUnitTest is DssTest {
 
     function test_auth_valid() public {
         checkAuth(address(new ValidAuthContract()), "AuthContract");

--- a/src/tests/FileUnitTest.t.sol
+++ b/src/tests/FileUnitTest.t.sol
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import "../DSSTest.sol";
+import "../DssTest.sol";
 
 contract ValidFileContract {
     mapping (address => uint256) public wards;
@@ -132,7 +132,7 @@ contract InvalidFileContractMissingAuth {
     }
 }
 
-contract FileUnitTest is DSSTest {
+contract FileUnitTest is DssTest {
 
     function test_file_uint_valid() public {
         checkFileUint(address(new ValidFileContract()), "FileContract", ["someData"]);

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -17,7 +17,7 @@ pragma solidity ^0.8.16;
 
 import "dss-interfaces/Interfaces.sol";
 
-import "../DSSTest.sol";
+import "../DssTest.sol";
 import "../domains/RootDomain.sol";
 import "../domains/OptimismDomain.sol";
 import "../domains/ArbitrumDomain.sol";
@@ -37,7 +37,7 @@ interface ArbitrumDaiBridgeLike {
     function l2Counterpart() external view returns (address);
 }
 
-contract IntegrationTest is DSSTest {
+contract IntegrationTest is DssTest {
 
     using GodMode for *;
     using MCD for DssInstance;

--- a/src/tests/ModifierUnitTest.t.sol
+++ b/src/tests/ModifierUnitTest.t.sol
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import "../DSSTest.sol";
+import "../DssTest.sol";
 
 contract SomeContract {
     modifier myModifier { if (1 != 0) revert("SomeContract/bad-state"); _; }    // Conditional gets rid of code unreachable warning
@@ -23,7 +23,7 @@ contract SomeContract {
     function withoutModifier(uint256 arg) external {}
 }
 
-contract ModifierUnitTest is DSSTest {
+contract ModifierUnitTest is DssTest {
 
     function test_modifier() public {
         checkModifier(address(new SomeContract()), "SomeContract/bad-state", [abi.encodeWithSelector(SomeContract.withModifier.selector)]);

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-import "../DSSTest.sol";
+import "../DssTest.sol";
 import "../ScriptTools.sol";
 
-contract ScriptToolTest is DSSTest {
+contract ScriptToolTest is DssTest {
 
     function test_stringToBytes32() public {
         assertEq(ScriptTools.stringToBytes32("test"),  bytes32("test"));


### PR DESCRIPTION
Before continuing to integrate this dependency in other repos I'd like to do this change.
It is a nit but makes it more standard according on how we have been using `Dss` in other repos contract naming.