### PR TITLE
Refactor how contract exports and imports work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cache/
 out/
+script/output/**/*.json

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,7 @@ out = 'out'
 libs = ['lib']
 fs_permissions = [
     { access = "read", path = "./script/input/"},
+    { access = "read-write", path = "./script/output/"},
     { access = "read", path = "./out/ArbitrumDomain.sol/ArbSysOverride.json"}
 ]
 

--- a/src/DssTest.sol
+++ b/src/DssTest.sol
@@ -55,10 +55,6 @@ abstract contract DssTest is Test {
     event File(bytes32 indexed what, uint256 data);
     event File(bytes32 indexed what, address data);
 
-    function readInput(string memory input) internal view returns (string memory) {
-        return ScriptTools.readInput(input);
-    }
-
     /**
      * @notice Takes the root chain into account when finding relative chains.
      *         Ex. if the root chain id is 5 then "optimism" will convert to "optimism_goerli", etc

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -45,7 +45,7 @@ library ScriptTools {
     function readOutput(string memory name, uint256 timestamp) internal view returns (string memory) {
         string memory root = vm.projectRoot();
         string memory chainOutputFolder = string(abi.encodePacked("/script/output/", vm.toString(getRootChainId()), "/"));
-        return vm.readFile(string(abi.encodePacked(root, chainOutputFolder, name, "-", vm.toString(block.timestamp), ".json")));
+        return vm.readFile(string(abi.encodePacked(root, chainOutputFolder, name, "-", vm.toString(timestamp), ".json")));
     }
 
     function readOutput(string memory name) internal view returns (string memory) {

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -111,11 +111,8 @@ library ScriptTools {
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
      */
-    function exportContract(string memory json, string memory name, address addr) internal returns (string memory) {
-        return vm.serializeAddress(EXPORT_JSON_KEY, name, addr);
-    }
-
-    function writeExports(string memory json, string memory name) internal {
+    function exportContract(string memory name, string memory label, address addr) internal {
+        string memory json = vm.serializeAddress(EXPORT_JSON_KEY, label, addr);
         string memory root = vm.projectRoot();
         string memory chainOutputFolder = string(abi.encodePacked("/script/output/", vm.toString(getRootChainId()), "/"));
         vm.writeJson(json, string(abi.encodePacked(root, chainOutputFolder, name, "-", vm.toString(block.timestamp), ".json")));

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -110,6 +110,9 @@ library ScriptTools {
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
      *         Note waiting on Foundry to have better primatives, but roll our own for now.
+     * @param name The name to give the json file.
+     * @param label The label of the address.
+     * @param addr The address to export.
      */
     function exportContract(string memory name, string memory label, address addr) internal {
         string memory json = vm.serializeAddress(EXPORT_JSON_KEY, label, addr);

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -79,12 +79,14 @@ library ScriptTools {
 
     /**
      * @notice Used to export important contracts to higher level deploy scripts.
-     *         Note waiting on Foundry to have better primatives, but roll our own for now.
+     *         Note waiting on Foundry to have better primitives, but roll our own for now.
+     * @dev Set FOUNDRY_EXPORTS_NAME to override the name of the json file.
      * @param name The name to give the json file.
      * @param label The label of the address.
      * @param addr The address to export.
      */
     function exportContract(string memory name, string memory label, address addr) internal {
+        name = vm.envOr("FOUNDRY_EXPORTS_NAME", name);
         string memory json = vm.serializeAddress(EXPORT_JSON_KEY, label, addr);
         string memory root = vm.projectRoot();
         string memory chainOutputFolder = string(abi.encodePacked("/script/output/", vm.toString(getRootChainId()), "/"));
@@ -92,6 +94,17 @@ library ScriptTools {
         if (!vm.envOr("FOUNDRY_EXPORTS_NO_OVERWRITE_LATEST", false)) {
             vm.writeJson(json, string(abi.encodePacked(root, chainOutputFolder, name, "-latest.json")));
         }
+    }
+
+    /**
+     * @notice Used to export important contracts to higher level deploy scripts.
+     *         Note waiting on Foundry to have better primitives, but roll our own for now.
+     * @dev Requires FOUNDRY_EXPORTS_NAME to be set.
+     * @param label The label of the address.
+     * @param addr The address to export.
+     */
+    function exportContract(string memory label, address addr) internal {
+        exportContract(vm.envString("FOUNDRY_EXPORTS_NAME"), label, addr);
     }
 
     /**

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -55,7 +55,7 @@ contract IntegrationTest is DssTest {
     ArbitrumDomain arbitrum;
 
     function setUp() public virtual {
-        config = readInput("integration");
+        config = ScriptTools.readInput("integration");
 
         rootDomain = new RootDomain(config, getRelativeChain("mainnet"));
         rootDomain.selectFork();

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -20,6 +20,9 @@ import "../ScriptTools.sol";
 
 contract ScriptToolTest is DssTest {
 
+    string exports;
+    string loadedExports;
+
     function test_stringToBytes32() public {
         assertEq(ScriptTools.stringToBytes32("test"),  bytes32("test"));
     }
@@ -46,6 +49,18 @@ contract ScriptToolTest is DssTest {
 
     function test_not_eq() public {
         assertTrue(!ScriptTools.eq("A", "B"));
+    }
+
+    function test_export_contracts() public {
+        // Export some contracts
+        exports = ScriptTools.exportContract(exports, "label1", address(123));
+        exports = ScriptTools.exportContract(exports, "label2", address(456));
+        ScriptTools.writeExports(exports, "myExports");
+
+        // Simulate a subsequent run loading a previously written file
+        loadedExports = ScriptTools.readOutput("myExports-latest");
+        assertEq(stdJson.readAddress(loadedExports, "label1"), address(123));
+        assertEq(stdJson.readAddress(loadedExports, "label2"), address(456));
     }
 
 }

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -55,8 +55,8 @@ contract ScriptToolTest is DssTest {
         ScriptTools.exportContract("myExports", "label1", address(1));
         ScriptTools.exportContract("myExports", "label2", address(2));
 
-        // Simulate a subsequent run loading a previously written file
-        loadedExports = ScriptTools.readOutput("myExports-latest");
+        // Simulate a subsequent run loading a previously written file (use latest deploy)
+        loadedExports = ScriptTools.readOutput("myExports");
         assertEq(stdJson.readAddress(loadedExports, "label1"), address(1));
         assertEq(stdJson.readAddress(loadedExports, "label2"), address(2));
     }

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -20,7 +20,6 @@ import "../ScriptTools.sol";
 
 contract ScriptToolTest is DssTest {
 
-    string exports;
     string loadedExports;
 
     function test_stringToBytes32() public {
@@ -52,15 +51,14 @@ contract ScriptToolTest is DssTest {
     }
 
     function test_export_contracts() public {
-        // Export some contracts
-        exports = ScriptTools.exportContract(exports, "label1", address(123));
-        exports = ScriptTools.exportContract(exports, "label2", address(456));
-        ScriptTools.writeExports(exports, "myExports");
+        // Export some contracts and write to output
+        ScriptTools.exportContract("myExports", "label1", address(1));
+        ScriptTools.exportContract("myExports", "label2", address(2));
 
         // Simulate a subsequent run loading a previously written file
         loadedExports = ScriptTools.readOutput("myExports-latest");
-        assertEq(stdJson.readAddress(loadedExports, "label1"), address(123));
-        assertEq(stdJson.readAddress(loadedExports, "label2"), address(456));
+        assertEq(stdJson.readAddress(loadedExports, "label1"), address(1));
+        assertEq(stdJson.readAddress(loadedExports, "label2"), address(2));
     }
 
 }

--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,8 @@ set -e
 [[ "$FOUNDRY_ROOT_CHAINID" == "1" ]] && echo "Running tests on Mainnet"
 [[ "$FOUNDRY_ROOT_CHAINID" == "5" ]] && echo "Running tests on Goerli"
 
+mkdir -p "script/output/$FOUNDRY_ROOT_CHAINID"
+
 export FOUNDRY_ROOT_CHAINID
 if [[ -z "$1" ]]; then
     forge test


### PR DESCRIPTION
An improvement to how contract exports and imports are handled. I never liked the previous way. This one will export timestamped deployments in json format which can then be loaded by subsequent calls to `forge script`.

Also removed `readInput` from DssTest as it's deprecated and we are making breaking changes atm.