### PR TITLE
allow a custom root for readInput

### DIFF
--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -38,6 +38,10 @@ library ScriptTools {
 
     function readInput(string memory name) internal view returns (string memory) {
         string memory root = vm.projectRoot();
+        return readInput(root, name);
+    }
+
+    function readInput(string memory root, string memory name) internal view returns (string memory) {
         string memory chainInputFolder = string(abi.encodePacked("/script/input/", vm.toString(getRootChainId()), "/"));
         return vm.readFile(string(abi.encodePacked(root, chainInputFolder, name, ".json")));
     }


### PR DESCRIPTION
When using multichain testing in spells we have to copy the input config json which could create a maintenance challenge if addresses change.  This would allow a repo to pull the config from `dss-test` directly.