### PR TITLE
Improve Message Relay Robustness

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ libs = ['lib']
 fs_permissions = [
     { access = "read", path = "./script/input/"},
     { access = "read-write", path = "./script/output/"},
-    { access = "read", path = "./out/ArbitrumDomain.sol/ArbSysOverride.json"}
+    { access = "read", path = "./out/"}
 ]
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/src/domains/ArbitrumDomain.sol
+++ b/src/domains/ArbitrumDomain.sol
@@ -17,10 +17,21 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Vm.sol";
 
+import { RecordedLogs } from "./RecordedLogs.sol";
 import { Domain, BridgedDomain } from "./BridgedDomain.sol";
 import { StdChains } from "forge-std/StdChains.sol";
 
 interface InboxLike {
+    function createRetryableTicket(
+        address destAddr,
+        uint256 arbTxCallValue,
+        uint256 maxSubmissionCost,
+        address submissionRefundAddress,
+        address valueRefundAddress,
+        uint256 maxGas,
+        uint256 gasPriceBid,
+        bytes calldata data
+    ) external payable returns (uint256);
     function bridge() external view returns (address);
 }
 
@@ -102,7 +113,7 @@ contract ArbitrumDomain is BridgedDomain {
         selectFork();
 
         // Read all L1 -> L2 messages and relay them under Arbitrum fork
-        Vm.Log[] memory logs = vm.getRecordedLogs();
+        Vm.Log[] memory logs = RecordedLogs.getLogs();
         for (uint256 i = 0; i < logs.length; i++) {
             Vm.Log memory log = logs[i];
             if (log.topics[0] == MESSAGE_DELIVERED_TOPIC) {
@@ -136,7 +147,7 @@ contract ArbitrumDomain is BridgedDomain {
         hostDomain.selectFork();
 
         // Read all L2 -> L1 messages and relay them under host fork
-        Vm.Log[] memory logs = vm.getRecordedLogs();
+        Vm.Log[] memory logs = RecordedLogs.getLogs();
         for (uint256 i = 0; i < logs.length; i++) {
             Vm.Log memory log = logs[i];
             if (log.topics[0] == SEND_TO_L1_TOPIC) {

--- a/src/domains/OptimismDomain.sol
+++ b/src/domains/OptimismDomain.sol
@@ -21,6 +21,11 @@ import { Domain, BridgedDomain } from "./BridgedDomain.sol";
 import { StdChains } from "forge-std/StdChains.sol";
 
 interface MessengerLike {
+    function sendMessage(
+        address target,
+        bytes memory message,
+        uint32 gasLimit
+    ) external;
     function relayMessage(
         address _target,
         address _sender,

--- a/src/domains/OptimismDomain.sol
+++ b/src/domains/OptimismDomain.sol
@@ -56,10 +56,17 @@ contract OptimismDomain is BridgedDomain {
     bytes32 constant WITHDRAW_IDENTIFIER = 0x02a52367d10742d8032712c1bb8e0144ff1ec5ffda1ed7d70bb05a2744955054;
     uint160 constant OFFSET = uint160(0x1111000000000000000000000000000000001111);
 
+    uint256 internal lastFromHostLogIndex;
+    uint256 internal lastToHostLogIndex;
+
     constructor(string memory _config, StdChains.Chain memory _chain, Domain _hostDomain) Domain(_config, _chain) BridgedDomain(_hostDomain) {
         l1Messenger = MessengerLike(readConfigAddress("l1Messenger"));
         l2Messenger = MessengerLike(readConfigAddress("l2Messenger"));
         vm.recordLogs();
+    }
+
+    function isGoerli() private view returns (bool) {
+        return keccak256(bytes(details().chainAlias)) == keccak256(bytes("optimism_goerli"));
     }
 
     function relayFromHost(bool switchToGuest) external override {
@@ -71,13 +78,14 @@ contract OptimismDomain is BridgedDomain {
 
         // Read all L1 -> L2 messages and relay them under Optimism fork
         Vm.Log[] memory logs = RecordedLogs.getLogs();
-        for (uint256 i = 0; i < logs.length; i++) {
-            Vm.Log memory log = logs[i];
-            if (log.topics[0] == SENT_MESSAGE_TOPIC && logs[i - 1].topics[0] == DEPOSIT_IDENTIFIER) {
+        if (!isGoerli() && lastToHostLogIndex > lastFromHostLogIndex) lastFromHostLogIndex = lastToHostLogIndex;
+        for (; lastFromHostLogIndex < logs.length; lastFromHostLogIndex++) {
+            Vm.Log memory log = logs[lastFromHostLogIndex];
+            if (log.topics[0] == SENT_MESSAGE_TOPIC && (!isGoerli() || logs[lastFromHostLogIndex - 1].topics[0] == DEPOSIT_IDENTIFIER)) {
                 address target = address(uint160(uint256(log.topics[1])));
                 (address sender, bytes memory message, uint256 nonce, uint256 gasLimit) = abi.decode(log.data, (address, bytes, uint256, uint256));
                 vm.startPrank(malias);
-                if (block.chainid == 420) {
+                if (isGoerli()) {
                     // Goerli has been upgraded to bedrock which has a new relay interface
                     BedrockMessengerLike(address(l2Messenger)).relayMessage(nonce, sender, target, 0, gasLimit, message);
                 } else {
@@ -98,9 +106,10 @@ contract OptimismDomain is BridgedDomain {
         // Read all L2 -> L1 messages and relay them under Primary fork
         // Note: We bypass the L1 messenger relay here because it's easier to not have to generate valid state roots / merkle proofs
         Vm.Log[] memory logs = RecordedLogs.getLogs();
-        for (uint256 i = 0; i < logs.length; i++) {
-            Vm.Log memory log = logs[i];
-            if (log.topics[0] == SENT_MESSAGE_TOPIC && logs[i - 1].topics[0] == WITHDRAW_IDENTIFIER) {
+        if (!isGoerli() && lastFromHostLogIndex > lastToHostLogIndex) lastToHostLogIndex = lastFromHostLogIndex;
+        for (; lastToHostLogIndex < logs.length; lastToHostLogIndex++) {
+            Vm.Log memory log = logs[lastToHostLogIndex];
+            if (log.topics[0] == SENT_MESSAGE_TOPIC && (!isGoerli() || logs[lastToHostLogIndex - 1].topics[0] == WITHDRAW_IDENTIFIER)) {
                 address target = address(uint160(uint256(log.topics[1])));
                 (address sender, bytes memory message,,) = abi.decode(log.data, (address, bytes, uint256, uint256));
                 // Set xDomainMessageSender

--- a/src/domains/RecordedLogs.sol
+++ b/src/domains/RecordedLogs.sol
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity >=0.8.0;
+
+import { Vm } from "forge-std/Vm.sol";
+
+contract RecordedLogsStorage {
+
+    Vm.Log[] private _logs;
+
+    constructor() {
+    }
+
+    function addLogs(Vm.Log[] memory newLogs) public {
+        for (uint256 i = 0; i < newLogs.length; i++) {
+            _logs.push(newLogs[i]);
+        }
+    }
+
+    function getLogs() public view returns (Vm.Log[] memory) {
+        return _logs;
+    }
+
+}
+
+library RecordedLogs {
+
+    RecordedLogsStorage public constant STORAGE = RecordedLogsStorage(address(uint160(uint256(keccak256("RECORDED_LOGS_STORAGE")))));
+
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function isContract(address _addr) private view returns (bool){
+        uint32 size;
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return (size > 0);
+    }
+
+    function checkInitialized() private {
+        if (!isContract(address(STORAGE))) {
+            bytes memory bytecode = vm.getCode("RecordedLogs.sol:RecordedLogsStorage");
+            address deployed;
+            assembly {
+                deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+            }
+            vm.etch(address(STORAGE), deployed.code);
+            vm.makePersistent(address(STORAGE));
+        }
+    }
+
+    function getLogs() internal returns (Vm.Log[] memory) {
+        checkInitialized();
+        STORAGE.addLogs(vm.getRecordedLogs());
+        return STORAGE.getLogs();
+    }
+
+}

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -205,20 +205,102 @@ contract IntegrationTest is DssTest {
         assertEq(dss.dai.balanceOf(address(this)), 75 ether);
     }
 
-    function test_optimism_message_ordering() public {
-        MessageOrdering mo1 = new MessageOrdering();
+    function test_optimism_message_ordering_targeting_and_persistence() public {
+        MessageOrdering moRoot = new MessageOrdering();
 
         optimism.selectFork();
 
-        MessageOrdering mo2 = new MessageOrdering();
+        MessageOrdering moOptimism = new MessageOrdering();
 
+        // Queue up some L2 -> L1 messages
+        optimism.l2Messenger().sendMessage(
+            address(moRoot),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 3),
+            100000
+        );
+        optimism.l2Messenger().sendMessage(
+            address(moRoot),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 4),
+            100000
+        );
+
+        // Do not relay right away
         rootDomain.selectFork();
 
-        optimism.l2Messenger().sendMessage(
-            guest,
-            abi.encodeWithSelector(DomainGuestLike.finalizeSettle.selector, sourceDomain, targetDomain, _amount),
-            gasLimit
+        // Queue up two more L1 -> L2 messages
+        optimism.l1Messenger().sendMessage(
+            address(moOptimism),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 1),
+            100000
         );
+        optimism.l1Messenger().sendMessage(
+            address(moOptimism),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 2),
+            100000
+        );
+
+        optimism.relayFromHost(true);
+
+        assertEq(moOptimism.messages(0), 1);
+        assertEq(moOptimism.messages(1), 2);
+
+        optimism.relayToHost(true);
+
+        assertEq(moRoot.messages(0), 3);
+        assertEq(moRoot.messages(1), 4);
+    }
+
+    function test_arbitrum_message_ordering_targeting_and_persistence() public {
+        MessageOrdering moRoot = new MessageOrdering();
+
+        arbitrum.selectFork();
+
+        MessageOrdering moArbitrum = new MessageOrdering();
+
+        // Queue up some L2 -> L1 messages
+        ArbSysOverride(arbitrum.arbSys()).sendTxToL1(
+            address(moRoot),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 3)
+        );
+        ArbSysOverride(arbitrum.arbSys()).sendTxToL1(
+            address(moRoot),
+            abi.encodeWithSelector(MessageOrdering.push.selector, 4)
+        );
+
+        // Do not relay right away
+        rootDomain.selectFork();
+
+        // Queue up two more L1 -> L2 messages
+        arbitrum.inbox().createRetryableTicket{value: 1 ether}(
+            address(moArbitrum),
+            0,
+            1 ether,
+            msg.sender,
+            msg.sender,
+            100000,
+            0,
+            abi.encodeWithSelector(MessageOrdering.push.selector, 1)
+        );
+        arbitrum.inbox().createRetryableTicket{value: 1 ether}(
+            address(moArbitrum),
+            0,
+            1 ether,
+            msg.sender,
+            msg.sender,
+            100000,
+            0,
+            abi.encodeWithSelector(MessageOrdering.push.selector, 2)
+        );
+
+        arbitrum.relayFromHost(true);
+
+        assertEq(moArbitrum.messages(0), 1);
+        assertEq(moArbitrum.messages(1), 2);
+
+        arbitrum.relayToHost(true);
+
+        assertEq(moRoot.messages(0), 3);
+        assertEq(moRoot.messages(1), 4);
     }
 
 }

--- a/src/tests/IntegrationTest.t.sol
+++ b/src/tests/IntegrationTest.t.sol
@@ -206,6 +206,8 @@ contract IntegrationTest is DssTest {
     }
 
     function test_optimism_message_ordering_targeting_and_persistence() public {
+        if (block.chainid == 1) return;   // Ignoring mainnet optimism test for now because there is no differentiator for message direction before Bedrock upgrade
+
         MessageOrdering moRoot = new MessageOrdering();
 
         optimism.selectFork();


### PR DESCRIPTION
Increase the robustness of messages. This will persist log messages to a predefined address, and have relays keep track of what they've sent already.

Note: Optimism Mainnet L1 -> L2 and L2 -> L1 messages are identical in the logs, so there is no easy way to differentiate. Since Bedrock upgrade is coming soon (which does differentiate) I figure having Optimism relay messages one at a time is fine for now.