### PR TITLE
Dont return all recorded logs for every relay

### DIFF
--- a/src/domains/ArbitrumDomain.sol
+++ b/src/domains/ArbitrumDomain.sol
@@ -116,12 +116,13 @@ contract ArbitrumDomain is BridgedDomain {
         selectFork();
 
         // Read all L1 -> L2 messages and relay them under Arbitrum fork
-        Vm.Log[] memory logs = RecordedLogs.getLogs();
-        for (; lastFromHostLogIndex < logs.length; lastFromHostLogIndex++) {
-            Vm.Log memory log = logs[lastFromHostLogIndex];
+        Vm.Log[] memory logs = RecordedLogs.getLogs(lastFromHostLogIndex);
+        lastFromHostLogIndex += logs.length;
+        for (uint256 i = 0; i < logs.length; i++) {
+            Vm.Log memory log = logs[i];
             if (log.topics[0] == MESSAGE_DELIVERED_TOPIC) {
                 // We need both the current event and the one that follows for all the relevant data
-                Vm.Log memory logWithData = logs[lastFromHostLogIndex + 1];
+                Vm.Log memory logWithData = logs[i + 1];
                 (,, address sender,,,) = abi.decode(log.data, (address, uint8, address, bytes32, uint256, uint64));
                 (address target, bytes memory message) = parseData(logWithData.data);
                 vm.startPrank(sender);
@@ -150,9 +151,10 @@ contract ArbitrumDomain is BridgedDomain {
         hostDomain.selectFork();
 
         // Read all L2 -> L1 messages and relay them under host fork
-        Vm.Log[] memory logs = RecordedLogs.getLogs();
-        for (; lastToHostLogIndex < logs.length; lastToHostLogIndex++) {
-            Vm.Log memory log = logs[lastToHostLogIndex];
+        Vm.Log[] memory logs = RecordedLogs.getLogs(lastToHostLogIndex);
+        lastToHostLogIndex += logs.length;
+        for (uint256 i = 0; i < logs.length; i++) {
+            Vm.Log memory log = logs[i];
             if (log.topics[0] == SEND_TO_L1_TOPIC) {
                 (address sender, address target, bytes memory message) = abi.decode(log.data, (address, address, bytes));
                 l2ToL1Sender = sender;

--- a/src/domains/RecordedLogs.sol
+++ b/src/domains/RecordedLogs.sol
@@ -34,6 +34,17 @@ contract RecordedLogsStorage {
         return _logs;
     }
 
+    function getLogs(uint256 startIndex) public view returns (Vm.Log[] memory) {
+        if (startIndex >= _logs.length) {
+            return new Vm.Log[](0);
+        }
+        Vm.Log[] memory logs = new Vm.Log[](_logs.length - startIndex);
+        for (uint256 i = startIndex; i < _logs.length; i++) {
+            logs[i - startIndex] = _logs[i];
+        }
+        return logs;
+    }
+
 }
 
 library RecordedLogs {
@@ -66,6 +77,12 @@ library RecordedLogs {
         checkInitialized();
         STORAGE.addLogs(vm.getRecordedLogs());
         return STORAGE.getLogs();
+    }
+
+    function getLogs(uint256 startIndex) internal returns (Vm.Log[] memory) {
+        checkInitialized();
+        STORAGE.addLogs(vm.getRecordedLogs());
+        return STORAGE.getLogs(startIndex);
     }
 
 }


### PR DESCRIPTION
It's wasteful to copy all logs every relay. Instead use the latest that you need.