### PR TITLE
Extend ScriptTools and Domain to support export & loading of address arrays

### DIFF
--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -142,6 +142,21 @@ library ScriptTools {
     }
 
     /**
+     * @notice Used to export important contracts to higher level deploy scripts. Specifically,
+     *         this function exports an array of contracts under the same key (label).
+     *         Note waiting on Foundry to have better primitives, but roll our own for now.
+     * @dev Set FOUNDRY_EXPORTS_NAME to override the name of the json file.
+     * @param name The name to give the json file.
+     * @param label The label of the address.
+     * @param addr The addresses to export.
+     */
+    function exportContracts(string memory name, string memory label, address[] memory addr) internal {
+        name = vm.envOr("FOUNDRY_EXPORTS_NAME", name);
+        string memory json = vm.serializeAddress(string(abi.encodePacked(EXPORT_JSON_KEY, "_", name)), label, addr);
+        _doExport(name, json);
+    }
+
+    /**
      * @notice Used to export important values to higher level deploy scripts.
      *         Note waiting on Foundry to have better primitives, but roll our own for now.
      * @dev Requires FOUNDRY_EXPORTS_NAME to be set.

--- a/src/ScriptTools.sol
+++ b/src/ScriptTools.sol
@@ -147,7 +147,7 @@ library ScriptTools {
      *         Note waiting on Foundry to have better primitives, but roll our own for now.
      * @dev Set FOUNDRY_EXPORTS_NAME to override the name of the json file.
      * @param name The name to give the json file.
-     * @param label The label of the address.
+     * @param label The label of the addresses.
      * @param addr The addresses to export.
      */
     function exportContracts(string memory name, string memory label, address[] memory addr) internal {

--- a/src/domains/Domain.sol
+++ b/src/domains/Domain.sol
@@ -39,12 +39,21 @@ contract Domain {
         vm.makePersistent(address(this));
     }
 
+    function hasConfigKey(string memory key) internal view returns (bool) {
+        bytes memory raw = config.parseRaw(string.concat(".domains.", _details.chainAlias, ".", key));
+        return raw.length > 0;
+    }
+
     function readConfigString(string memory key) public view returns (string memory) {
         return config.readString(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function readConfigAddress(string memory key) public view returns (address) {
         return config.readAddress(string.concat(".domains.", _details.chainAlias, ".", key));
+    }
+
+    function readConfigAddresses(string memory key) internal view returns (address[] memory) {
+        return config.readAddressArray(string.concat(".domains.", _details.chainAlias, ".", key));
     }
 
     function readConfigUint(string memory key) public view returns (uint256) {

--- a/src/tests/ScriptToolsTest.t.sol
+++ b/src/tests/ScriptToolsTest.t.sol
@@ -54,11 +54,16 @@ contract ScriptToolTest is DssTest {
         // Export some contracts and write to output
         ScriptTools.exportContract("myExports", "addr1", address(0x1));
         ScriptTools.exportContract("myExports", "addr2", address(0x2));
+        address[] memory addr34 = new address[](2);
+        addr34[0] = address(0x3);
+        addr34[1] = address(0x4);
+        ScriptTools.exportContracts("myExports", "addr34", addr34);
 
         // Simulate a subsequent run loading a previously written file (use latest deploy)
         loadedExports = ScriptTools.readOutput("myExports", 1);
         assertEq(stdJson.readAddress(loadedExports, ".addr1"), address(0x1));
         assertEq(stdJson.readAddress(loadedExports, ".addr2"), address(0x2));
+        assertEq(stdJson.readAddressArray(loadedExports, ".addr34"), addr34);
 
         // Export some values and write to output
         ScriptTools.exportValue("myExports", "label1", 1);


### PR DESCRIPTION
The ability to load address arrays from config and to export address arrays is used by the scripts in https://github.com/makerdao/op-token-bridge, 
https://github.com/makerdao/arbitrum-token-bridge, 
https://github.com/makerdao/op-farms and 
https://github.com/makerdao/arbitrum-farms